### PR TITLE
 Add PNG/SVG Export Feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 All notable changes to the "dbml-previewer" extension will be documented in this file.
 
+## 1.1.0
+
+### Added
+- **PNG Export**: Export diagrams as high-resolution PNG images (2x pixel ratio for crisp quality)
+- **SVG Export**: Export diagrams as scalable vector graphics for presentations and documentation
+- **Export Configuration Options**: Three new settings to customize export output:
+  - `diagram.exportQuality` (0.1-1.0, default: 0.95) - PNG image quality control
+  - `diagram.exportBackground` (boolean, default: true) - Toggle background inclusion for transparent exports
+  - `diagram.exportPadding` (0-100px, default: 20) - Configurable padding around exported diagrams
+- **Export Commands**: New VSCode commands accessible via Command Palette:
+  - "Export Diagram to PNG" - Export current diagram as PNG image
+  - "Export Diagram to SVG" - Export current diagram as SVG vector image
+- **Export UI Buttons**: Convenient export buttons in the stats panel (top-right):
+  - 📷 Export PNG button
+  - 🖼️ Export SVG button
+- **Smart Filename Generation**: Automatic timestamped filenames based on DBML file name
+
+### Improved
+- **Clean Export Output**: UI controls (minimap, panels, navigation) automatically hidden during export
+- **Professional Image Quality**: High-resolution exports suitable for documentation and presentations
+- **Transparent Background Support**: Option to export diagrams with transparent backgrounds for flexible use
+- **Error Handling**: Graceful error recovery with automatic UI restoration if export fails
+
+### Technical
+- Added `html-to-image@1.11.11` dependency (recommended version per XY Flow documentation)
+- Enhanced `DBMLPreview.js` with export handlers: `handleExportToPng()` and `handleExportToSvg()`
+- Updated `extension.js` with export command registration and active panel tracking
+- Implemented context management (`dbmlPreviewerActive`) for command availability
+- Added temporary UI hiding during export with automatic restoration
+- Configuration synchronization between extension and webview for export settings
+
 ## 1.0.0
 
 ### Added
@@ -177,11 +208,11 @@ All notable changes to the "dbml-previewer" extension will be documented in this
 ## [Unreleased]
 
 ### Planned Features
-- Export options (PNG, SVG, PDF)
-- Search and filter functionality
-- Theme customization options
-- Minimap for large schemas
+- Export to PDF format
+- Advanced search and filter functionality
+- Custom theme creation and color schemes
 - Schema comparison tools
 - Performance optimizations for very large databases
 - Column note tooltips enhancement
 - Bulk table operations
+- Diagram statistics and analytics

--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ Perfect for database architects, developers, and anyone working with database sc
 
 ## 🌟 What's New
 
+### v1.1.0 - Export Feature Release
+- 📤 **Export to PNG/SVG**: Save your diagrams as high-quality images
+- 🎛️ **Export Configuration**: Customize image quality, background, and padding
+- ⌨️ **Multiple Access Points**: Export via UI buttons or VSCode commands
+- 🖼️ **Professional Output**: High-resolution exports with transparent background option
+
 ### v1.0.0 - Major Configuration Release
 - ⚙️ **Theme Configuration**: Choose between VS Code theme inheritance or clean light theme (default: light)
 - 🔗 **Edge Type Options**: 4 relationship line styles - straight, step, smoothstep, and bezier
@@ -48,7 +54,13 @@ Perfect for database architects, developers, and anyone working with database sc
 ✅ **Flexible Theming** - Choose VS Code theme inheritance or clean light theme
 ✅ **Multiple Access Points** - Command palette, context menu, keyboard shortcuts
 ✅ **Side-by-Side Editing** - Preview alongside your DBML file
-✅ **Quick Access** - `Ctrl+Shift+D` / `Cmd+Shift+D` keyboard shortcut  
+✅ **Quick Access** - `Ctrl+Shift+D` / `Cmd+Shift+D` keyboard shortcut
+
+### 📤 **Professional Export Capabilities**
+✅ **PNG Export** - High-resolution raster images for documentation
+✅ **SVG Export** - Scalable vector graphics for presentations
+✅ **Configurable Quality** - Adjust image quality and resolution
+✅ **Background Control** - Export with or without background color  
 
 ## 🚀 Get Started in 30 Seconds
 
@@ -162,14 +174,42 @@ The extension works out of the box with sensible defaults and includes the follo
     - `"smoothstep"` - Smooth step edges with rounded corners (recommended)
     - `"bezier"` - Curved bezier edges for organic appearance
 
+### Export Configuration
+- **`diagram.exportQuality`** (number, default: `0.95`)
+  - Image quality for PNG exports (0.1 to 1.0)
+  - Higher values produce better quality but larger file sizes
+  - Recommended: 0.95 for high-quality exports
+
+- **`diagram.exportBackground`** (boolean, default: `true`)
+  - Include background in exported images
+  - When disabled, exported images have transparent background
+  - Useful for presentations and documentation
+
+- **`diagram.exportPadding`** (number, default: `20`)
+  - Padding around the diagram in exported images (in pixels)
+  - Range: 0-100 pixels
+  - Provides visual breathing room around your diagram
+
 ### How to Configure
 1. Open VS Code Settings (`Ctrl+,` / `Cmd+,`)
 2. Search for "diagram" or "DBML Previewer"
 3. Adjust settings to your preference
 4. Changes apply immediately without restart
 
+### How to Export
+**Via UI Buttons (recommended):**
+1. Open any DBML file and preview it
+2. Look for export buttons in the top-right stats panel
+3. Click "📷 Export PNG" or "🖼️ Export SVG"
+4. Image downloads automatically with timestamped filename
+
+**Via Command Palette:**
+1. Open Command Palette (`Ctrl+Shift+P` / `Cmd+Shift+P`)
+2. Search for "Export Diagram to PNG" or "Export Diagram to SVG"
+3. Execute the command
+4. Image downloads automatically
+
 ### Future Configuration Options
-- Export settings and formats
 - Performance optimization toggles
 - Advanced layout algorithm options
 
@@ -219,12 +259,6 @@ If you encounter any problems:
 - 💻 **VS Code**: 1.102.0+
 - 📄 **File Format**: `.dbml` files (DBML v2 syntax)
 - 🚀 **Zero Setup**: No additional dependencies required!
-
-## 🛣️ What's Coming Next
-
-### 🔜 **Coming Soon**
-- 📤 **Export to PNG/SVG/PDF** - Save your diagrams
-- 🎨 **Custom Themes** - Personalize your diagrams
 
 ## 📄 License
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "dbml-previewer",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dbml-previewer",
-      "version": "0.0.1",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@dbml/core": "^3.2.0",
         "@xyflow/react": "^12.0.0",
         "dagre": "^0.8.5",
+        "html-to-image": "1.11.11",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },
@@ -4198,6 +4199,12 @@
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/html-to-image": {
+      "version": "1.11.11",
+      "resolved": "https://registry.npmjs.org/html-to-image/-/html-to-image-1.11.11.tgz",
+      "integrity": "sha512-9gux8QhvjRO/erSnDPv28noDZcPZmYE7e1vFsBLKLlRlKDSqNJYebj6Qz1TGd5lsRV+X+xYyjCKjuZdABinWjA==",
       "license": "MIT"
     },
     "node_modules/http-proxy-agent": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "dbml-previewer",
   "displayName": "DBML Previewer",
   "description": "Transform DBML files into interactive visual database diagrams with drag-and-drop tables, relationship tooltips, multi-schema support, and real-time preview updates",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "publisher": "rizkykurniawan",
   "author": {
     "name": "Rizky Kurniawan",
@@ -59,6 +59,18 @@
         "command": "dbml-previewer.previewFromExplorer",
         "title": "Preview DBML",
         "category": "DBML Previewer"
+      },
+      {
+        "command": "dbml-previewer.exportToPNG",
+        "title": "Export Diagram to PNG",
+        "category": "DBML Previewer",
+        "icon": "$(device-camera)"
+      },
+      {
+        "command": "dbml-previewer.exportToSVG",
+        "title": "Export Diagram to SVG",
+        "category": "DBML Previewer",
+        "icon": "$(file-media)"
       }
     ],
     "menus": {
@@ -91,6 +103,14 @@
         {
           "command": "dbml-previewer.previewFromExplorer",
           "when": "false"
+        },
+        {
+          "command": "dbml-previewer.exportToPNG",
+          "when": "dbmlPreviewerActive"
+        },
+        {
+          "command": "dbml-previewer.exportToSVG",
+          "when": "dbmlPreviewerActive"
         }
       ]
     },
@@ -140,6 +160,25 @@
             "Bezier curve edge"
           ],
           "description": "The type of edge/connection lines to use for table relationships in the diagram."
+        },
+        "diagram.exportQuality": {
+          "type": "number",
+          "default": 0.95,
+          "minimum": 0.1,
+          "maximum": 1.0,
+          "description": "Image quality for PNG exports (0.1 to 1.0). Higher values produce better quality but larger file sizes."
+        },
+        "diagram.exportBackground": {
+          "type": "boolean",
+          "default": true,
+          "description": "Include background in exported images. When disabled, exported images have a transparent background."
+        },
+        "diagram.exportPadding": {
+          "type": "number",
+          "default": 20,
+          "minimum": 0,
+          "maximum": 100,
+          "description": "Padding around the diagram in exported images (in pixels)."
         }
       }
     }
@@ -159,7 +198,8 @@
     "react-dom": "^18.2.0",
     "@xyflow/react": "^12.0.0",
     "dagre": "^0.8.5",
-    "@dbml/core": "^3.2.0"
+    "@dbml/core": "^3.2.0",
+    "html-to-image": "1.11.11"
   },
   "devDependencies": {
     "@types/vscode": "^1.102.0",


### PR DESCRIPTION
# Summary

  Adds the ability to export DBML diagrams as PNG and SVG images with configurable settings.

  # What's New

  - Export to PNG: High-resolution raster image export (2x pixel ratio)
  - Export to SVG: Scalable vector graphics export
  - Export Settings: Quality, background, and padding configuration
  - UI Buttons: Export buttons in stats panel (PNG, SVG)
  - Commands: "Export Diagram to PNG/SVG" in Command Palette
  - Clean Output: UI controls automatically hidden during export

  # Technical Changes

  - Added html-to-image@1.11.11 dependency
  - Implemented export handlers in DBMLPreview.js
  - Added export commands and context management in extension.js
  - Added 3 new configuration options in package.json
  - Updated documentation in README.md and CHANGELOG.md

  # Configuration Options

  - diagram.exportQuality (0.1-1.0, default: 0.95)
  - diagram.exportBackground (boolean, default: true)
  - diagram.exportPadding (0-100px, default: 20)
