### PR TITLE
index issue fixed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2245,14 +2245,14 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.23",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.23.tgz",
       "integrity": "sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -3295,7 +3295,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/d3-color": {

--- a/scratch_index.js
+++ b/scratch_index.js
@@ -1,0 +1,19 @@
+const { Parser } = require('@dbml/core');
+const fs = require('fs');
+const util = require('util');
+
+const dbml = `
+Table users {
+  id integer [primary key]
+  username varchar
+  created_at timestamp
+  
+  Indexes {
+    username [name: 'idx_username']
+    (id, username)
+  }
+}
+`;
+
+const parsed = Parser.parse(dbml, 'dbml');
+console.log(util.inspect(parsed.schemas[0].tables[0].indexes, { depth: 3 }));

--- a/src/webview/components/ColumnNode.js
+++ b/src/webview/components/ColumnNode.js
@@ -9,6 +9,7 @@ const ColumnNode = ({ data }) => {
     if (column.pk) return '🔑';
     if (column.unique) return '⚡';
     if (column.not_null) return '❗';
+    if (column.hasIndex) return '🔍';
     return '';
   };
 

--- a/src/webview/components/TableNode.js
+++ b/src/webview/components/TableNode.js
@@ -9,6 +9,7 @@ const TableNode = ({ data }) => {
     if (column.pk) return '🔑';
     if (column.unique) return '⚡';
     if (column.not_null) return '❗';
+    if (column.hasIndex) return '🔍';
     return ''; // Remove the bullet point
   };
 

--- a/src/webview/utils/dbmlPreprocessor.js
+++ b/src/webview/utils/dbmlPreprocessor.js
@@ -45,7 +45,7 @@ const extractBaseTableName = (rawName) => {
 const findLastTableName = (contentBefore) => {
   const matches = [
     ...contentBefore.matchAll(
-      /\bTable\s+(?:"[^"]*"\.)?"?([\w$]+)"?[^{]*\{/gi
+      /\bTable\s+(?:(?:"[^"]*"|[\w$]+)\.)?"?([\w$]+)"?[^{]*\{/gi
     ),
   ];
   if (matches.length === 0) return null;

--- a/src/webview/utils/dbmlTransformer.js
+++ b/src/webview/utils/dbmlTransformer.js
@@ -342,6 +342,20 @@ export const transformDBMLToNodes = (dbmlData, savedPositions = {}, onColumnClic
     const tableGroup = tableToGroupMap[table.name];
     const checks = tableChecks[table.name] || [];
 
+    // Collect indexed column names
+    const indexedColumnNames = new Set();
+    if (table.indexes) {
+      table.indexes.forEach(index => {
+        if (index.columns) {
+          index.columns.forEach(col => {
+            if (col.type === 'column' && col.value) {
+              indexedColumnNames.add(col.value);
+            }
+          });
+        }
+      });
+    }
+
     // Create table header node (parent) with schema-aware ID
     const tableHeaderNode = {
       id: `table-${table.fullName}`,
@@ -373,6 +387,11 @@ export const transformDBMLToNodes = (dbmlData, savedPositions = {}, onColumnClic
       // Check if this column type is an enum
       const columnTypeName = column.type?.type_name;
       const enumDef = columnTypeName ? findEnumForType(columnTypeName, allEnums) : null;
+      
+      // Attach hasIndex flag to column object directly
+      if (indexedColumnNames.has(column.name)) {
+        column.hasIndex = true;
+      }
       
       const columnNode = {
         id: `${table.fullName}.${column.name}`,


### PR DESCRIPTION

`
**Feature: Add index icon to columns**

This PR adds a small visual update to show a magnifying glass icon (`🔍`) next to columns that are indexed. Before this, the extension was ignoring the `Indexes` block in DBML entirely. 

**What I changed:**
- **`dbmlTransformer.js`**: Added logic to loop through `table.indexes`, grab the indexed column names, and attach a `hasIndex` flag to them.
- **`ColumnNode.js` & `TableNode.js`**: Updated the `getColumnIcon` function. If a column has `hasIndex` set to true (and isn't already marked as a PK, Unique, or Not Null), it will now show the `🔍` icon.

Tested it locally with a DBML file that has indexes and the icons are showing up correctly in both table views! Let me know if anything needs to be changed.
```