### PR TITLE
Feature/index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to the "dbml-previewer" extension will be documented in this file.
 
+## 1.5.0
+
+### Added
+- **Indexes Support**: Tables with `indexes { ... }` blocks now display an "🔍 View Indexes" button at the bottom of the table
+  - Click to open a detailed popup showing all indexes with their name, type, uniqueness, columns, and notes
+  - Badges for primary key (PK), unique, and index type (e.g. btree)
+  - Works alongside existing checks support with proper footer stacking
+
+### Fixed
+- **Checks not showing with unquoted schema names**: Fixed an issue where table-level checks were not displayed when the schema name was not enclosed in double quotes (e.g. `Table Schema.TableName` vs `Table "Schema".TableName`)
+
 ## 1.4.0
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -14,13 +14,11 @@ Perfect for database architects, developers, and anyone working with database sc
 
 ## 🌟 What's New
 
-### v1.4.0 - Layout & Export Enhancement Release
+### v1.5.0 - Index Support Release
 
-- 💾 **Persistent Layout**: Table positions are saved to a JSON file and restored automatically across sessions
-- 📦 **Bulk Export**: Export all DBML files in a folder to PNG or SVG at once
-- 🏷️ **Cardinality Labels**: Show 0/1/N labels on relationship edges (toggle via `diagram.showCardinalityLabels`)
+- 🔍 **Indexes Support**: Tables with `indexes { ... }` blocks now show indexes in a popup with name, type, columns, and badges (PK, unique)
+- 🐛 **Checks Fix**: Table-level checks now display correctly when the schema name is unquoted
 - ✅ **CHECK Keyword Support**: Full support for DBML `check` column constraint
-- 🎨 **Relationship Line Colors**: Custom colors on relationship lines
 
 ## ⚡ Key Features
 
@@ -153,7 +151,7 @@ This extension supports the full DBML specification including:
 - ✅ **Indexes** (simple and composite)
 - ✅ **Table Groups** for schema organization
 - ✅ **Custom Colors** for tables (`headercolor`) and groups (`color`)
-- ✅ **CHECK Constraints** - Column-level check constraint support
+- ✅ **CHECK Constraints** - Table-level and column-level check constraint support
 - ✅ **Multi-schema** database support
 - ✅ **Default Values** and **Auto-increment** fields
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "dbml-previewer",
   "displayName": "DBML Previewer",
   "description": "Transform DBML files into interactive visual database diagrams with drag-and-drop tables, relationship tooltips, multi-schema support, and real-time preview updates",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "publisher": "rizkykurniawan",
   "author": {
     "name": "Rizky Kurniawan",

--- a/src/webview/components/DBMLPreview.js
+++ b/src/webview/components/DBMLPreview.js
@@ -22,6 +22,7 @@ import EdgeTooltip from './EdgeTooltip';
 import ColumnTooltip from './ColumnTooltip';
 import TableNoteTooltip from './TableNoteTooltip';
 import TableChecksTooltip from './TableChecksTooltip';
+import TableIndexesTooltip from './TableIndexesTooltip';
 import StickyNote from './StickyNote';
 import ErrorDisplay from './ErrorDisplay';
 import TableNavigationDropdown from './TableNavigationDropdown';
@@ -132,6 +133,7 @@ const DBMLPreview = ({ initialContent }) => {
   const [columnTooltipData, setColumnTooltipData] = useState(null);
   const [tableNoteTooltipData, setTableNoteTooltipData] = useState(null);
   const [tableChecksTooltipData, setTableChecksTooltipData] = useState(null);
+  const [tableIndexesTooltipData, setTableIndexesTooltipData] = useState(null);
   const [tableGroups, setTableGroups] = useState([]);
   const [draggedGroupPositions, setDraggedGroupPositions] = useState(new Map());
   const [fileId, setFileId] = useState(null);
@@ -398,6 +400,7 @@ const DBMLPreview = ({ initialContent }) => {
     setTooltipData(null);
     setSelectedEdgeIds(new Set());
     setTableNoteTooltipData(null);
+    setTableIndexesTooltipData(null);
 
     // Open column tooltip
     setColumnTooltipData({
@@ -413,6 +416,7 @@ const DBMLPreview = ({ initialContent }) => {
     setTooltipData(null);
     setSelectedEdgeIds(new Set());
     setColumnTooltipData(null);
+    setTableIndexesTooltipData(null);
 
     // Open table note tooltip
     setTableNoteTooltipData({
@@ -438,12 +442,28 @@ const DBMLPreview = ({ initialContent }) => {
     setSelectedEdgeIds(new Set());
     setColumnTooltipData(null);
     setTableNoteTooltipData(null);
+    setTableIndexesTooltipData(null);
     setTableChecksTooltipData({ table, checks, position });
   }, []);
 
   // Handle checks tooltip close
   const handleCloseTableChecksTooltip = useCallback(() => {
     setTableChecksTooltipData(null);
+  }, []);
+
+  // Handle indexes button click for tooltip display
+  const handleTableIndexesClick = useCallback((table, indexes, position) => {
+    setTooltipData(null);
+    setSelectedEdgeIds(new Set());
+    setColumnTooltipData(null);
+    setTableNoteTooltipData(null);
+    setTableChecksTooltipData(null);
+    setTableIndexesTooltipData({ table, indexes, position });
+  }, []);
+
+  // Handle indexes tooltip close
+  const handleCloseTableIndexesTooltip = useCallback(() => {
+    setTableIndexesTooltipData(null);
   }, []);
 
 
@@ -455,6 +475,8 @@ const DBMLPreview = ({ initialContent }) => {
         setSelectedEdgeIds(new Set());
         setColumnTooltipData(null);
         setTableNoteTooltipData(null);
+        setTableChecksTooltipData(null);
+        setTableIndexesTooltipData(null);
       }
     };
 
@@ -468,6 +490,8 @@ const DBMLPreview = ({ initialContent }) => {
         setSelectedEdgeIds(new Set());
         setColumnTooltipData(null);
         setTableNoteTooltipData(null);
+        setTableChecksTooltipData(null);
+        setTableIndexesTooltipData(null);
       }
     };
 
@@ -502,11 +526,17 @@ const DBMLPreview = ({ initialContent }) => {
         groupTables.forEach(tableNode => {
           const { x, y } = tableNode.position;
           const tableWidth = tableNode.data.tableWidth || 200;
+          const checksCount = tableNode.data.checksCount || 0;
+          const indexesCount = tableNode.data.indexesCount || 0;
+          const checksFooterHeight = checksCount > 0 ? 32 : 0;
+          const indexesFooterHeight = indexesCount > 0 ? 32 : 0;
           const tableHeight =
             42 + // header height
             (tableNode.data.table?.note ? 30 : 0) + // note height
             (tableNode.data.columnCount * 30) + // columns height
-            16; // padding
+            16 + // padding
+            checksFooterHeight +
+            indexesFooterHeight;
 
           minX = Math.min(minX, x);
           minY = Math.min(minY, y);
@@ -563,13 +593,13 @@ const DBMLPreview = ({ initialContent }) => {
       window.vscode.postMessage({ type: 'clearLayout' });
       // Trigger re-transform with empty positions
       if (dbmlData) {
-        const { nodes: newNodes, edges: newEdges, tableGroups: newTableGroups } = transformDBMLToNodes(dbmlData, {}, handleColumnClick, handleTableNoteClick, edgeType, tableChecks, handleTableChecksClick, showCardinalityLabels);
+        const { nodes: newNodes, edges: newEdges, tableGroups: newTableGroups } = transformDBMLToNodes(dbmlData, {}, handleColumnClick, handleTableNoteClick, edgeType, tableChecks, handleTableChecksClick, showCardinalityLabels, handleTableIndexesClick);
         setNodes(newNodes);
         setEdges(newEdges);
         setTableGroups(newTableGroups || []);
       }
     }
-  }, [fileId, dbmlData, edgeType, showCardinalityLabels, tableChecks, setNodes, setEdges, handleColumnClick, handleTableNoteClick, handleTableChecksClick]);
+  }, [fileId, dbmlData, edgeType, showCardinalityLabels, tableChecks, setNodes, setEdges, handleColumnClick, handleTableNoteClick, handleTableChecksClick, handleTableIndexesClick]);
 
   // Custom nodes change handler that handles TableGroup dragging
   const handleNodesChange = useCallback((changes) => {
@@ -912,7 +942,7 @@ const DBMLPreview = ({ initialContent }) => {
           saveLayout(fileId, cleanedPositions);
         }
 
-        const { nodes: newNodes, edges: newEdges, tableGroups: newTableGroups } = transformDBMLToNodes(dbmlData, cleanedPositions, handleColumnClick, handleTableNoteClick, edgeType, tableChecks, handleTableChecksClick, showCardinalityLabels);
+        const { nodes: newNodes, edges: newEdges, tableGroups: newTableGroups } = transformDBMLToNodes(dbmlData, cleanedPositions, handleColumnClick, handleTableNoteClick, edgeType, tableChecks, handleTableChecksClick, showCardinalityLabels, handleTableIndexesClick);
         setNodes(newNodes);
         setEdges(newEdges);
         setTableGroups(newTableGroups || []);
@@ -1198,6 +1228,15 @@ const DBMLPreview = ({ initialContent }) => {
           checks={tableChecksTooltipData.checks}
           position={tableChecksTooltipData.position}
           onClose={handleCloseTableChecksTooltip}
+        />
+      )}
+
+      {tableIndexesTooltipData && (
+        <TableIndexesTooltip
+          table={tableIndexesTooltipData.table}
+          indexes={tableIndexesTooltipData.indexes}
+          position={tableIndexesTooltipData.position}
+          onClose={handleCloseTableIndexesTooltip}
         />
       )}
     </div>

--- a/src/webview/components/TableHeaderNode.js
+++ b/src/webview/components/TableHeaderNode.js
@@ -10,8 +10,10 @@ const TableHeaderNode = ({ data }) => {
     hasMultipleSchema = false,
     onTableNoteClick,
     onTableChecksClick,
+    onTableIndexesClick,
   } = data;
   const checks = table.checks || [];
+  const indexes = table.indexes || [];
 
   // Calculate dimensions based on content
   const headerHeight = 42; // Header section height
@@ -19,7 +21,9 @@ const TableHeaderNode = ({ data }) => {
   const tablePadding = 8; // Padding around column area
   // Fixed-height footer for the "View Checks" button when checks are present
   const checksFooterHeight = checks.length > 0 ? 32 : 0;
-  const totalHeight = headerHeight + (columnCount * columnHeight) + (tablePadding * 2) + checksFooterHeight;
+  // Fixed-height footer for the "View Indexes" button when indexes are present
+  const indexesFooterHeight = indexes.length > 0 ? 32 : 0;
+  const totalHeight = headerHeight + (columnCount * columnHeight) + (tablePadding * 2) + checksFooterHeight + indexesFooterHeight;
 
   let title = table.name;
   if (hasMultipleSchema && table.schemaName) {
@@ -97,8 +101,8 @@ const TableHeaderNode = ({ data }) => {
           borderTop: `1px solid ${getThemeVar('panelBorder')}`,
           borderLeft: `2px solid ${getThemeVar('panelBorder')}`,
           borderRight: `2px solid ${getThemeVar('panelBorder')}`,
-          borderBottom: checks.length > 0 ? 'none' : `2px solid ${getThemeVar('panelBorder')}`,
-          borderRadius: checks.length > 0 ? '0' : '0 0 8px 8px',
+          borderBottom: (checks.length > 0 || indexes.length > 0) ? 'none' : `2px solid ${getThemeVar('panelBorder')}`,
+          borderRadius: (checks.length > 0 || indexes.length > 0) ? '0' : '0 0 8px 8px',
           background: getThemeVar('editorBackground'),
           height: `${columnCount * columnHeight + (tablePadding * 2)}px`,
           boxSizing: 'border-box'
@@ -112,9 +116,9 @@ const TableHeaderNode = ({ data }) => {
         <div style={{
           borderLeft: `2px solid ${getThemeVar('panelBorder')}`,
           borderRight: `2px solid ${getThemeVar('panelBorder')}`,
-          borderBottom: `2px solid ${getThemeVar('panelBorder')}`,
+          borderBottom: indexes.length > 0 ? 'none' : `2px solid ${getThemeVar('panelBorder')}`,
           borderTop: `1px solid ${getThemeVar('panelBorder')}`,
-          borderRadius: '0 0 8px 8px',
+          borderRadius: indexes.length > 0 ? '0' : '0 0 8px 8px',
           background: getThemeVar('editorBackground'),
           height: `${checksFooterHeight}px`,
           boxSizing: 'border-box',
@@ -147,6 +151,50 @@ const TableHeaderNode = ({ data }) => {
             title="View check constraints"
           >
             ✓ View Checks ({checks.length})
+          </button>
+        </div>
+      )}
+
+      {/* Indexes Footer — shows a compact button to open the indexes tooltip */}
+      {indexes.length > 0 && (
+        <div style={{
+          borderLeft: `2px solid ${getThemeVar('panelBorder')}`,
+          borderRight: `2px solid ${getThemeVar('panelBorder')}`,
+          borderBottom: `2px solid ${getThemeVar('panelBorder')}`,
+          borderTop: `1px solid ${getThemeVar('panelBorder')}`,
+          borderRadius: '0 0 8px 8px',
+          background: getThemeVar('editorBackground'),
+          height: `${indexesFooterHeight}px`,
+          boxSizing: 'border-box',
+          display: 'flex',
+          alignItems: 'center',
+          padding: '0 8px',
+        }}>
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              if (onTableIndexesClick) {
+                const rect = e.currentTarget.getBoundingClientRect();
+                onTableIndexesClick(table, indexes, {
+                  x: rect.right + 10,
+                  y: rect.top,
+                });
+              }
+            }}
+            style={{
+              background: 'none',
+              border: `1px solid ${getThemeVar('panelBorder')}`,
+              borderRadius: '4px',
+              color: getThemeVar('descriptionForeground'),
+              cursor: 'pointer',
+              fontSize: '11px',
+              padding: '3px 8px',
+              width: '100%',
+              textAlign: 'left',
+            }}
+            title="View indexes"
+          >
+            🔍 View Indexes ({indexes.length})
           </button>
         </div>
       )}

--- a/src/webview/components/TableIndexesTooltip.js
+++ b/src/webview/components/TableIndexesTooltip.js
@@ -1,0 +1,185 @@
+import React, { useEffect, useRef } from 'react';
+import { getThemeVar } from '../styles/themeManager.js';
+
+const TableIndexesTooltip = ({ table, indexes, position, onClose }) => {
+  const tooltipRef = useRef(null);
+
+  useEffect(() => {
+    const handleClickOutside = (event) => {
+      if (tooltipRef.current && !tooltipRef.current.contains(event.target)) {
+        onClose();
+      }
+    };
+
+    const handleEscKey = (event) => {
+      if (event.key === 'Escape') {
+        onClose();
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    document.addEventListener('keydown', handleEscKey);
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('keydown', handleEscKey);
+    };
+  }, [onClose]);
+
+  if (!table || !indexes || indexes.length === 0 || !position) {
+    return null;
+  }
+
+  const tooltipStyle = {
+    position: 'fixed',
+    left: Math.min(position.x, window.innerWidth - 360),
+    top: Math.min(position.y, window.innerHeight - 200),
+    zIndex: 1000,
+    background: getThemeVar('editorBackground'),
+    border: `1px solid ${getThemeVar('panelBorder')}`,
+    borderRadius: '6px',
+    padding: '12px',
+    minWidth: '300px',
+    maxWidth: '360px',
+    fontSize: '12px',
+    color: getThemeVar('foreground'),
+    boxShadow: '0 4px 12px rgba(0, 0, 0, 0.15)',
+    fontFamily: getThemeVar('fontFamily'),
+  };
+
+  const badgeStyle = {
+    display: 'inline-block',
+    fontSize: '9px',
+    fontWeight: 'bold',
+    padding: '1px 5px',
+    borderRadius: '3px',
+    marginRight: '4px',
+    textTransform: 'uppercase',
+  };
+
+  const renderBadges = (index) => {
+    const badges = [];
+    if (index.pk) {
+      badges.push(
+        <span key="pk" style={{ ...badgeStyle, background: getThemeVar('inputValidationErrorBackground'), color: getThemeVar('inputValidationErrorForeground'), border: `1px solid ${getThemeVar('inputValidationErrorBorder')}` }}>
+          PK
+        </span>
+      );
+    }
+    if (index.unique) {
+      badges.push(
+        <span key="unique" style={{ ...badgeStyle, background: getThemeVar('inputValidationInfoBackground'), color: getThemeVar('inputValidationInfoForeground'), border: `1px solid ${getThemeVar('inputValidationInfoBorder')}` }}>
+          UNIQUE
+        </span>
+      );
+    }
+    if (index.type) {
+      badges.push(
+        <span key="type" style={{ ...badgeStyle, background: 'transparent', color: getThemeVar('descriptionForeground'), border: `1px solid ${getThemeVar('panelBorder')}` }}>
+          {index.type}
+        </span>
+      );
+    }
+    return badges;
+  };
+
+  return (
+    <div ref={tooltipRef} style={tooltipStyle} data-tooltip="table-indexes">
+      {/* Header */}
+      <div style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: '8px',
+        marginBottom: '10px',
+        borderBottom: `1px solid ${getThemeVar('panelBorder')}`,
+        paddingBottom: '8px',
+      }}>
+        <span style={{ fontSize: '14px' }}>🔍</span>
+        <span style={{
+          fontWeight: 'bold',
+          fontSize: '14px',
+          color: getThemeVar('foreground'),
+        }}>
+          {table.name}
+        </span>
+        <span style={{
+          fontSize: '11px',
+          color: getThemeVar('descriptionForeground'),
+          marginLeft: '2px',
+        }}>
+          — Indexes
+        </span>
+        <button
+          onClick={onClose}
+          style={{
+            marginLeft: 'auto',
+            background: 'none',
+            border: 'none',
+            color: getThemeVar('iconForeground'),
+            cursor: 'pointer',
+            fontSize: '16px',
+            padding: '2px',
+            borderRadius: '2px',
+          }}
+          title="Close"
+        >
+          ×
+        </button>
+      </div>
+
+      {/* Index items */}
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '10px' }}>
+        {indexes.map((index, i) => {
+          const columns = index.columns || [];
+          const columnNames = columns
+            .map(col => col.type === 'expression' ? `(${col.value})` : col.value)
+            .join(', ');
+
+          return (
+            <div key={i} style={{
+              borderLeft: `3px solid ${getThemeVar('panelBorder')}`,
+              paddingLeft: '8px',
+            }}>
+              <div style={{
+                display: 'flex',
+                alignItems: 'center',
+                flexWrap: 'wrap',
+                gap: '4px',
+                marginBottom: '3px',
+              }}>
+                <span style={{
+                  fontSize: '12px',
+                  fontWeight: 'bold',
+                  color: getThemeVar('foreground'),
+                }}>
+                  {index.name || `Unnamed Index`}
+                </span>
+                {renderBadges(index)}
+              </div>
+              <div style={{
+                fontSize: '11px',
+                color: getThemeVar('descriptionForeground'),
+                fontFamily: 'monospace',
+                wordBreak: 'break-all',
+              }}>
+                {columnNames || '(no columns)'}
+              </div>
+              {index.note && (
+                <div style={{
+                  fontSize: '10px',
+                  color: getThemeVar('descriptionForeground'),
+                  marginTop: '2px',
+                  fontStyle: 'italic',
+                }}>
+                  {index.note}
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+export default TableIndexesTooltip;

--- a/src/webview/utils/dbmlTransformer.js
+++ b/src/webview/utils/dbmlTransformer.js
@@ -210,7 +210,7 @@ const analyzeColumnRelationships = (refs, tables, hasMultipleSchema) => {
   return columnHandles;
 };
 
-export const transformDBMLToNodes = (dbmlData, savedPositions = {}, onColumnClick = null, onTableNoteClick = null, edgeType = 'smoothstep', tableChecks = {}, onTableChecksClick = null, showCardinalityLabels = false) => {
+export const transformDBMLToNodes = (dbmlData, savedPositions = {}, onColumnClick = null, onTableNoteClick = null, edgeType = 'smoothstep', tableChecks = {}, onTableChecksClick = null, showCardinalityLabels = false, onTableIndexesClick = null) => {
   if (!dbmlData?.schemas || dbmlData.schemas.length === 0) {
     return { nodes: [], edges: [] };
   }
@@ -363,7 +363,7 @@ export const transformDBMLToNodes = (dbmlData, savedPositions = {}, onColumnClic
       position: { x: 0, y: 0 }, // Will be calculated by layout
       zIndex: 10,
       data: {
-        table: { ...table, checks },
+        table: { ...table, checks, indexes: table.indexes || [] },
         columnCount,
         tableWidth,
         hasMultipleSchema,
@@ -371,6 +371,8 @@ export const transformDBMLToNodes = (dbmlData, savedPositions = {}, onColumnClic
         onTableNoteClick,
         onTableChecksClick,
         checksCount: checks.length,
+        indexesCount: (table.indexes || []).length,
+        onTableIndexesClick,
       },
     };
     nodes.push(tableHeaderNode);
@@ -552,9 +554,10 @@ const getLayoutedElements = (nodes, edges, tableGroups = [], savedPositions = {}
   const tablePadding = 8;
   
   tableHeaderNodes.forEach((tableNode) => {
-    const { columnCount, tableWidth, checksCount = 0 } = tableNode.data;
+    const { columnCount, tableWidth, checksCount = 0, indexesCount = 0 } = tableNode.data;
     const checksFooterHeight = checksCount > 0 ? 32 : 0;
-    const totalHeight = headerHeight + (columnCount * columnHeight) + (tablePadding * 2) + checksFooterHeight;
+    const indexesFooterHeight = indexesCount > 0 ? 32 : 0;
+    const totalHeight = headerHeight + (columnCount * columnHeight) + (tablePadding * 2) + checksFooterHeight + indexesFooterHeight;
 
     tableDimensions[tableNode.id] = {
       width: tableWidth,


### PR DESCRIPTION
## Add Indexes Support to DBML Previewer

Adds full interactive index display support for DBML files, alongside a fix for checks not showing with unquoted schema names.

### Features

**Indexes popup on table nodes**
Tables with `indexes { ... }` blocks now show an **"🔍 View Indexes"** button footer, right below the existing checks footer when both are present. Clicking it opens a detailed popup displaying:

- **Index name** (or "Unnamed Index" fallback)
- **Badges**: `PK`, `UNIQUE`, and index type (e.g. `btree`)
- **Column list** (comma-separated, with expressions wrapped in parentheses)
- **Note** (italicized if present)

The footer buttons stack properly — column area → checks footer → indexes footer — with correct border-radius chaining.

### Fixes

close #31 

- **Checks not showing with unquoted schema names** 
  — Fixed regex in `dbmlPreprocessor.js` to match both `Table "Schema".Name` and `Table Schema.Name` patterns

### Files Changed

| File | Change |
|------|--------|
| `src/webview/components/TableIndexesTooltip.js` | **New** — Index details popup component (~185 lines) |
| `src/webview/components/TableHeaderNode.js` | Added indexes footer button, dual-footer border-radius logic |
| `src/webview/components/DBMLPreview.js` | State, handlers, render block, ESC/click-outside for indexes tooltip |
| `src/webview/utils/dbmlTransformer.js` | Pass indexes array to nodes; account for dual footers in layout dimensions |
| `src/webview/utils/dbmlPreprocessor.js` | Fix regex for unquoted schema names |
| `src/webview/components/ColumnNode.js` | Index icon already present from prior commit |
| `src/webview/components/TableNode.js` | Index icon already present from prior commit |

### How to Test

Use a `.dbml` file with:

```dbml
Table "Cores".Source {
  id smallint [pk, increment]
  code varchar [not null, unique]
  name varchar [not null]
  is_active boolean [not null, default: true]

  indexes {
    name
    code
  }

  checks {
    `is_active = false AND disabled_at IS NOT NULL`
    `is_active = true AND disabled_at IS NULL`
  }
}
```

- Verify the table footer shows both "✓ View Checks (2)" and "🔍 View Indexes (2)"
- Click each button and confirm the popups display correct details
- Test with / without quoted schema names
- Verify layout dimensions account for both footers (table height, group bounds)
- Test ESC and click-outside dismiss for both tooltips